### PR TITLE
Add keepAlive to the websocket client options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codex-data/sdk",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "engines": {
     "node": ">=17.5.0"
   },

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -42,6 +42,7 @@ export class Codex {
     });
     this.wsClient = createClient({
       webSocketImpl: WebSocket,
+      keepAlive: 10_000,
       url: this.apiRealtimeUrl,
       connectionParams: {
         Authorization: this.apiKey,


### PR DESCRIPTION
Fixes issues with the websockets disconnecting after periods of no-activity. Uses the `keepAlive` flag in the graphql websocket client constructor. Pings the server every 10 seconds. 