### PR TITLE
feat: allow overriding default fetch function

### DIFF
--- a/src/sdk/index.test.ts
+++ b/src/sdk/index.test.ts
@@ -230,6 +230,31 @@ describe("Codex", () => {
     });
   });
 
+  describe("fetch override", () => {
+    it("should use the fetch override", async () => {
+      const fetchMock = jest.fn((input, init) => {
+        console.log("fetchMock", input, init);
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              data: { getNetworks: [] },
+            }),
+            {
+              status: 200,
+              headers: new Headers({
+                "Content-Type": "application/json",
+              }),
+            },
+          ),
+        );
+      });
+
+      const sdkWithFetch = new Codex("test-key", { fetch: fetchMock });
+      await sdkWithFetch.query(getNetworksDocument, {});
+      expect(fetchMock).toHaveBeenCalled();
+    });
+  });
+
   describe("dispose", () => {
     it("should dispose websocket client when it exists", async () => {
       const mockDispose = jest.fn();

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -33,6 +33,9 @@ export type ApiConfig = {
 
   // Use this to apply dynamic headers to the requests
   applyHeaders?: () => Promise<Record<string, string>>;
+
+  // Use this to override the default fetch implementation.
+  fetch?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 };
 
 const defaultConfig: ApiConfig = {
@@ -83,6 +86,7 @@ export class Codex {
         "X-Apollo-Operation-Name": "query",
         ...config.headers,
       }),
+      fetch: config.fetch,
     });
   }
 


### PR DESCRIPTION
Adds a new parameter to ApiConfig to allows overriding the default fetch implementation with a custom one. This is useful if the consumer wants to mock fetch for tests or alternatively for creating a decorator to the default node fetch implementation for things like logging, metrics, etc.