### PR TITLE
Publish to #announcements when SDK is released.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,3 +23,15 @@ jobs:
       - run: npm publish --access public
         env:
           NPM_TOKEN: ${{secrets.CODEX_SDK_NPM_TOKEN}}
+
+      - name: Notify Discord
+        uses: SethCohen/github-releases-to-discord@v1
+        with:
+          webhook_url: ${{secrets.DISCORD_WEBHOOK_URL}}
+          color: "2105893"
+          username: "Codex SDK Release"
+          avatar_url: "https://avatars.githubusercontent.com/u/175457154?s=200&v=4"
+          content: "🚀 New SDK release is now available!"
+          footer_title: "Codex SDK Changelog"
+          reduce_headings: true
+          remove_github_reference_links: false


### PR DESCRIPTION
Adam has been manually posting when the sdk is released. This should lift that burden.

<img width="515" height="616" alt="image" src="https://github.com/user-attachments/assets/442eb2ee-d5e0-4fa4-8398-f94fb6570a89" />
