### PR TITLE
ci: automated patch release (bump + tag + GitHub Release)

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -3,11 +3,6 @@ name: Bump version
 # Bumps the patch version, commits, and pushes a v* tag.
 # Pushing the tag triggers release.yml, which builds, publishes to npm,
 # and cuts a GitHub Release.
-#
-# Triggered manually or remotely (e.g. from company-z/supergraph production CI)
-# via workflow_dispatch. The token used to push must be a PAT / GitHub App token
-# so that the resulting tag push re-triggers release.yml (the default GITHUB_TOKEN
-# does not trigger downstream workflows).
 
 on:
   workflow_dispatch:

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,34 @@
+name: Bump version
+
+# Bumps the patch version, commits, and pushes a v* tag.
+# Pushing the tag triggers release.yml, which builds, publishes to npm,
+# and cuts a GitHub Release.
+#
+# Triggered manually or remotely (e.g. from company-z/supergraph production CI)
+# via workflow_dispatch. The token used to push must be a PAT / GitHub App token
+# so that the resulting tag push re-triggers release.yml (the default GITHUB_TOKEN
+# does not trigger downstream workflows).
+
+on:
+  workflow_dispatch:
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.SDK_RELEASE_TOKEN }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: pnpm/action-setup@v4
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Bump patch version and tag
+        run: pnpm version patch -m "chore(release): %s"
+      - name: Push commit and tag
+        run: git push --follow-tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,3 +22,8 @@ jobs:
       - run: pnpm publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{secrets.CODEX_SDK_NPM_TOKEN}}
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
Enables remote-triggered automated releases (driven from `company-z/supergraph` production CI when the GraphQL schema changes).

- **`bump.yml`** (new): `workflow_dispatch` job that runs `pnpm version patch` (bumps `package.json` + creates `v*` tag) and pushes with `--follow-tags`. The tag push triggers the existing `release.yml`.
- **`release.yml`**: after `pnpm publish`, now also cuts a GitHub Release with auto-generated notes for the new tag.

## Required secret
`bump.yml` checks out / pushes with `secrets.SDK_RELEASE_TOKEN` — a PAT or GitHub App token with `contents: write`. Required (not the default `GITHUB_TOKEN`) so the tag push re-triggers `release.yml`.

## Flow
supergraph prod CI → workflow_dispatch bump.yml → patch bump + tag push → release.yml → build + npm publish + GitHub Release.