### PR TITLE
ci: cut GitHub Release in bump flow, not on every tag push

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   bump:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -24,6 +26,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Bump patch version and tag
-        run: 'pnpm version patch -m "chore(release): %s"'
+        id: bump
+        run: |
+          echo "tag=$(pnpm version patch -m 'chore(release): %s')" >> "$GITHUB_OUTPUT"
       - name: Push commit and tag
         run: git push --follow-tags
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.bump.outputs.tag }}
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,4 @@ jobs:
       - run: pnpm publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{secrets.CODEX_SDK_NPM_TOKEN}}
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.ref_name }}
-          generate_release_notes: true
+


### PR DESCRIPTION
## Why

We have two release paths that both end in a `v*` tag push (which fires `release.yml` → npm publish):

1. **Automatic** — `workflow_dispatch` → `bump.yml` bumps the version and pushes a tag.
2. **Manual** — a maintainer creates a Release in the GitHub UI, which creates the tag.

The previous `release.yml` ran `action-gh-release` on **every** tag push. For the manual flow the Release already exists (with hand-written notes), so it clobbered those notes with auto-generated ones. The automatic flow, meanwhile, produced no Release at all once that step was removed.

## What

- **`bump.yml`** — create the GitHub Release after pushing the tag (only the automatic flow needs one). Tag name is captured from `pnpm version` output. Added `permissions: contents: write` so `GITHUB_TOKEN` can create the release. Bump command moved to a block scalar to avoid the `:`-in-scalar YAML parse error.
- **`release.yml`** — dropped the release step; it stays npm-publish-only for both flows.

## Result

- Automatic flow → `bump.yml` cuts the Release.
- Manual flow → GitHub UI cuts the Release (notes preserved).
- `release.yml` → npm publish for both.